### PR TITLE
feature/multi-set-enhancements

### DIFF
--- a/src/support/multi_set.gleam
+++ b/src/support/multi_set.gleam
@@ -54,3 +54,15 @@ pub fn get(b: MultiSet(a, b), key: a) -> Result(List(b), Nil) {
 pub fn delete(b: MultiSet(a, b), key: a) -> MultiSet(a, b) {
   dict.delete(b, key)
 }
+
+pub fn pop(b: MultiSet(a, b), key: a) -> Result(#(b, MultiSet(a, b)), Nil) {
+  case dict.get(b, key) {
+    Ok([value, ..values]) ->
+      case values {
+        [] -> Ok(#(value, dict.delete(b, key)))
+        _ -> Ok(#(value, dict.upsert(b, key, fn(_) { values })))
+      }
+    Ok([]) -> Error(Nil)
+    Error(_) -> Error(Nil)
+  }
+}

--- a/src/support/multi_set.gleam
+++ b/src/support/multi_set.gleam
@@ -8,7 +8,24 @@ pub fn new() -> MultiSet(a, b) {
   dict.new()
 }
 
-pub fn add(b: MultiSet(a, b), key: a, value: b) -> MultiSet(a, b) {
+/// Add a new value to the multiset with `key` and `value`.
+/// If the key does not exist, it will be created.
+/// If the key does exist, the value will be appended to the list of values.
+/// Returns the updated multiset.
+///
+/// # Examples
+/// ```
+/// let multiset = multi_set.new()
+/// let multiset = multi_set.add(multiset, "a", 1)
+/// let multiset = multi_set.add(multiset, "a", 2)
+/// let multiset = multi_set.add(multiset, "b", 5)
+///
+/// assert multi_set.get(multiset, "a") == Some([1, 2])
+/// assert multi_set.get(multiset, "b") == Some([5])
+/// assert multi_set.get(multiset, "c") == None
+/// ```
+///
+pub fn add(to b: MultiSet(a, b), key key: a, value value: b) -> MultiSet(a, b) {
   dict.upsert(b, key, fn(existing) {
     case existing {
       Some(values) -> [value, ..values]
@@ -17,10 +34,23 @@ pub fn add(b: MultiSet(a, b), key: a, value: b) -> MultiSet(a, b) {
   })
 }
 
+/// Get the list of keys in the multiset.
+///
 pub fn keys(b: MultiSet(a, b)) -> List(a) {
   dict.keys(b)
 }
 
+/// Get the list of values for the key in the multiset.
+/// If the key does not exist, an `Error` is returned.
+/// If the key exists, the list of values is returned wrapped in an `Ok`.
+///
 pub fn get(b: MultiSet(a, b), key: a) -> Result(List(b), Nil) {
   dict.get(b, key)
+}
+
+/// Remove a value from the multiset with `key` and `value`.
+/// If the key does not exist, the multiset is returned unchanged.
+///
+pub fn delete(b: MultiSet(a, b), key: a) -> MultiSet(a, b) {
+  dict.delete(b, key)
 }

--- a/src/support/multi_set.gleam
+++ b/src/support/multi_set.gleam
@@ -55,6 +55,11 @@ pub fn delete(b: MultiSet(a, b), key: a) -> MultiSet(a, b) {
   dict.delete(b, key)
 }
 
+/// Pop a value from the head of the multi set with `key`.
+/// If the key does not exist, an `Error` is returned.
+/// If the key exists and has no values, an `Error` is returned.
+/// If the key exists, the head value is returned wrapped in an `Ok` along with the updated multiset.
+///
 pub fn pop(b: MultiSet(a, b), key: a) -> Result(#(b, MultiSet(a, b)), Nil) {
   case dict.get(b, key) {
     Ok([value, ..values]) ->
@@ -65,4 +70,14 @@ pub fn pop(b: MultiSet(a, b), key: a) -> Result(#(b, MultiSet(a, b)), Nil) {
     Ok([]) -> Error(Nil)
     Error(_) -> Error(Nil)
   }
+}
+
+pub fn reverse(b: MultiSet(a, b)) -> MultiSet(a, b) {
+  dict.keys(b)
+  |> list.fold(new(), fn(acc, key) {
+    case dict.get(b, key) {
+      Ok(values) -> dict.insert(acc, key, values |> list.reverse())
+      Error(_) -> panic as "key not found"
+    }
+  })
 }

--- a/test/support/multi_set_test.gleam
+++ b/test/support/multi_set_test.gleam
@@ -28,3 +28,11 @@ pub fn add_multiple_test() {
   |> multi_set.get(1)
   |> should.equal(Ok([2, 1]))
 }
+
+pub fn delete_test() {
+  multi_set.new()
+  |> multi_set.add(1, 1)
+  |> multi_set.delete(1)
+  |> multi_set.get(1)
+  |> should.equal(Error(Nil))
+}

--- a/test/support/multi_set_test.gleam
+++ b/test/support/multi_set_test.gleam
@@ -36,3 +36,22 @@ pub fn delete_test() {
   |> multi_set.get(1)
   |> should.equal(Error(Nil))
 }
+
+pub fn pop_test() {
+  let assert Ok(#(item, ms)) =
+    multi_set.new()
+    |> multi_set.add(1, 1)
+    |> multi_set.add(1, 2)
+    |> multi_set.pop(1)
+
+  item |> should.equal(2)
+  multi_set.keys(ms) |> should.equal([1])
+
+  let assert Ok(#(item, ms)) = multi_set.pop(ms, 1)
+  item |> should.equal(1)
+
+  multi_set.keys(ms) |> should.equal([])
+
+  let assert Error(_) = multi_set.pop(ms, 1)
+  let assert Error(_) = multi_set.pop(ms, 2)
+}


### PR DESCRIPTION
Here is the pull request description based on the provided context:

```
## Feature: Multi-Set Enhancements

This pull request introduces several enhancements to the `multi_set` module:

1. **Add `delete` method**: A new `delete` method has been added to the `multi_set` module, allowing users to remove an item from the multi-set for a given key.

2. **Add `pop` function**: A new `pop` function has been added to the `multi_set` module. This function allows removing and returning an item from the multi-set for a given key. If the key has multiple items, it will return the last item added and update the multi-set accordingly. If the key has no items, it will return an error.

3. **Add `reverse` method**: A new `reverse` method has been added to the `multi_set` module. This method reverses all lists in the multi-set, turning the default first-in-last-out behavior into a first-in-first-out behavior.

These changes are intended to provide more flexibility and functionality to the `multi_set` module, making it more useful for a wider range of use cases.
```