### PR TITLE
feat(2024/9): remove unused gleam/result import

### DIFF
--- a/src/year_2024/day_9/solution.gleam
+++ b/src/year_2024/day_9/solution.gleam
@@ -3,7 +3,6 @@ import atomic_array as aa
 import gleam/bool
 import gleam/int
 import gleam/list.{Continue, Stop}
-import gleam/result
 
 type Disk {
   Disk(


### PR DESCRIPTION
Here is the pull request description:

This pull request removes an unused `gleam/result` import from the codebase. The commit message `feat(2024/9): remove unused gleam/result import` indicates that this change is a feature update related to the 2024/9 release, and it removes an unused import statement.